### PR TITLE
Save/load ESCItem.custom_data

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/set_item_custom_data.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_item_custom_data.gd
@@ -1,0 +1,39 @@
+# `set_item_custom_data item custom_data`
+#
+# *** FOR INTERNAL USE ONLY ***
+#
+# Sets the "custom_data" of the item if it currently exists in the object manager.
+#
+# **Parameters**
+#
+# - *item* Global ID of the item
+# - *custom_data* Dictionary with custom data. If null empty dictionary will be assigned.
+#
+# @ESC
+extends ESCBaseCommand
+class_name SetItemCustomDataCommand
+
+
+# Return the descriptor of the arguments of this command
+func configure() -> ESCCommandArgumentDescriptor:
+	return ESCCommandArgumentDescriptor.new(
+		2,
+		[TYPE_STRING, TYPE_DICTIONARY],
+		[null, null]
+	)
+
+
+# Run the command
+func run(command_params: Array) -> int:
+	var global_id: String = command_params[0]
+	if escoria.object_manager.has(global_id):
+		var item = escoria.object_manager.get_object(global_id).node
+		if item is ESCItem:
+			item.set_custom_data(command_params[1])
+	return ESCExecution.RC_OK
+
+
+# Function called when the command is interrupted.
+func interrupt():
+	# Do nothing
+	pass

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -19,6 +19,9 @@ var parameters: Array = []
 # Conditions are combined using logical AND
 var conditions: Array = []
 
+# True if command was called from a string (usual case) instead of passing parameters directly.
+var commandCalledAsString = true
+
 func exported() -> Dictionary:
 	var export_dict: Dictionary = .exported()
 	export_dict.class = "ESCCommand"
@@ -27,9 +30,15 @@ func exported() -> Dictionary:
 	export_dict.conditions = conditions
 	return export_dict
 
+# Create a command from a command string or from name, parameters and conditions
+func _init(command_string: String, _name: String="", _parameters: Array=[], _conditions: Array=[]):
+	if _name != "":
+		name = _name
+		parameters = _parameters
+		conditions = _conditions
+		commandCalledAsString = false
+		return
 
-# Create a command from a command string
-func _init(command_string):
 	var command_regex = RegEx.new()
 	command_regex.compile(REGEX)
 
@@ -130,7 +139,7 @@ func run() -> int:
 		var argument_descriptor = command_object.configure()
 		var prepared_arguments = argument_descriptor.prepare_arguments(
 			self.parameters
-		)
+		) if commandCalledAsString else self.parameters
 
 		if command_object.validate(prepared_arguments):
 			escoria.logger.debug(
@@ -164,4 +173,3 @@ func interrupt():
 # Override of built-in _to_string function to display the statement.
 func _to_string() -> String:
 	return "%s: %s" % [name, str(parameters)]
-

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -108,6 +108,11 @@ func _set_interactive(value: bool):
 # A dictionary containing the data to be saved for this object.
 func get_save_data() -> Dictionary:
 	var save_data: Dictionary = {}
+
+	# Save custom_data from items
+	if self.node.has_method("get_custom_data"):
+		save_data["custom_data"] = self.node.get_custom_data()
+
 	save_data["active"] = self.active
 	save_data["interactive"] = self.interactive
 	save_data["state"] = self.state

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -964,3 +964,11 @@ func is_moving() -> bool:
 
 func get_directions_quantity() -> int:
 	return animations.dir_angles.size()
+
+
+func get_custom_data() -> Dictionary:
+	return custom_data
+
+
+func set_custom_data(data: Dictionary) -> void:
+	custom_data = data if (data != null) else {}

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -40,6 +40,7 @@ var _enable_terrain: EnableTerrainCommand
 var _set_active: SetActiveCommand
 var _set_active_if_exists: SetActiveIfExistsCommand
 var _set_interactive: SetInteractiveCommand
+var _set_item_custom_data: SetItemCustomDataCommand
 var _teleport_pos: TeleportPosCommand
 var _set_angle: SetAngleCommand
 var _set_direction: SetDirectionCommand
@@ -65,6 +66,7 @@ func _init():
 	_set_active = SetActiveCommand.new()
 	_set_active_if_exists = SetActiveIfExistsCommand.new()
 	_set_interactive = SetInteractiveCommand.new()
+	_set_item_custom_data = SetItemCustomDataCommand.new()
 	_teleport_pos = TeleportPosCommand.new()
 	_set_angle = SetAngleCommand.new()
 	_set_direction = SetDirectionCommand.new()
@@ -398,9 +400,25 @@ func load_game(id: int):
 				)
 			)
 
+		if save_game.objects[object_global_id].has("custom_data"):
+			var custom_data = save_game.objects[object_global_id]["custom_data"]
+			if custom_data.size() > 0:
+				escoria.logger.info(self, "saveItem %s size=%s" % [object_global_id, custom_data.size()])
+				escoria.logger.info(self, "saveItem %s" % [JSON.print(custom_data)])
+				load_statements.append(
+					ESCCommand.new(
+						"",
+						_set_item_custom_data.get_command_name(),
+						[
+							object_global_id,
+							custom_data
+						]
+					)
+				)
+
 		if object_global_id in [
 				escoria.object_manager.MUSIC,
-				escoria.object_manager.SOUND, 
+				escoria.object_manager.SOUND,
 				escoria.object_manager.SPEECH
 			]:
 			if save_game.objects[object_global_id]["state"] in [

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -403,8 +403,6 @@ func load_game(id: int):
 		if save_game.objects[object_global_id].has("custom_data"):
 			var custom_data = save_game.objects[object_global_id]["custom_data"]
 			if custom_data.size() > 0:
-				escoria.logger.info(self, "saveItem %s size=%s" % [object_global_id, custom_data.size()])
-				escoria.logger.info(self, "saveItem %s" % [JSON.print(custom_data)])
 				load_statements.append(
 					ESCCommand.new(
 						"",


### PR DESCRIPTION
I created the set_item_custom_data instead of assigning data directly to the item because I saw that's the way you are doing in load_game() for all objects.

I had a bunch of issues trying to pass the custom_data as a Dictionary to the command. Almost get it using JSON parse/toString, but ESCCommand's REGEX took the array as the condition. Finally I added a constructor to ESCCommand to pass arguments and conditions directly, instead of passing the command as a string. I think it can be useful in other parts of the code, for example to avoid the problem we had with set_global command, that was solved in a hacky way.

This is working in our project where the save games have items like this:
```
"turno_cocina_patata": {
  "active": true,
  "custom_data": {
    "count": 4,
    "count_textures": [ {
        "start": 1,
        "texture": "res://gymkhana/items/inventory/assets/turno_cocina_patata.png"
      }, {
        "start": 2,
        "texture": "res://gymkhana/items/inventory/assets/turno_cocina_dos_patatas.png"
      }, {
        "start": 3,
        "texture": "res://gymkhana/items/inventory/assets/turno_cocina_tres_patatas.png"
      }, {
        "start": 4,
        "texture": "res://gymkhana/items/inventory/assets/turno_cocina_cuatro_patatas.png"
    } ]
  },
  "interactive": true,
  "state": "default"
},
```
