### PR TITLE
fix(save): room_objects variable should have the objects, not the keys

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -355,7 +355,7 @@ func load_game(id: int):
 	
 	for room_id in save_game.objects.keys():
 		
-		var room_objects: Array = save_game.objects[room_id].keys()
+		var room_objects: Dictionary = save_game.objects[room_id]
 		
 		if room_id in ESCObjectManager.RESERVED_OBJECTS:
 			


### PR DESCRIPTION
I think `esc_save_manager Line 385` expects `room_objects` to have the objects, not the keys.

`
if room_objects[object_global_id].has("active")
`

PD: Glad to see you back :)